### PR TITLE
aligned 2021 build output location with 2020

### DIFF
--- a/Dynamo/SAMAnalyticalDynamoRevit/SAMAnalyticalDynamoRevit.csproj
+++ b/Dynamo/SAMAnalyticalDynamoRevit/SAMAnalyticalDynamoRevit.csproj
@@ -45,7 +45,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAMAnalyticalDynamoRevit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/Grasshopper/SAM.Analytical.Grasshopper.Revit/SAM.Analytical.Grasshopper.Revit.csproj
+++ b/Grasshopper/SAM.Analytical.Grasshopper.Revit/SAM.Analytical.Grasshopper.Revit.csproj
@@ -56,7 +56,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Analytical.Grasshopper.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/Grasshopper/SAM.Architectural.Grasshopper.Revit/SAM.Architectural.Grasshopper.Revit.csproj
+++ b/Grasshopper/SAM.Architectural.Grasshopper.Revit/SAM.Architectural.Grasshopper.Revit.csproj
@@ -56,7 +56,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Architectural.Grasshopper.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/Grasshopper/SAM.Core.Grasshopper.Revit/SAM.Core.Grasshopper.Revit.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper.Revit/SAM.Core.Grasshopper.Revit.csproj
@@ -56,7 +56,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Core.Grasshopper.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/SAM_Revit/SAM.Analytical.Revit/SAM.Analytical.Revit.csproj
+++ b/SAM_Revit/SAM.Analytical.Revit/SAM.Analytical.Revit.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Analytical.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/SAM_Revit/SAM.Core.Revit/SAM.Core.Revit.csproj
+++ b/SAM_Revit/SAM.Core.Revit/SAM.Core.Revit.csproj
@@ -58,7 +58,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Core.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/SAM_Revit/SAM.Geometry.Revit/SAM.Geometry.Revit.csproj
+++ b/SAM_Revit/SAM.Geometry.Revit/SAM.Geometry.Revit.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Geometry.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>

--- a/SAM_Revit/SAM.Units.Revit/SAM.Units.Revit.csproj
+++ b/SAM_Revit/SAM.Units.Revit/SAM.Units.Revit.csproj
@@ -58,7 +58,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug2021\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>..\..\build\SAM.Units.Revit.xml</DocumentationFile>
     <DebugType>full</DebugType>


### PR DESCRIPTION
 ### Issues addressed by this PR
Debug2021 build failure in devops due to RevitAPI dlls not in the build path

Fixes #79 
Changed build output location for Debug2021 to same as Debug2020


